### PR TITLE
Add import sorting recipe for JavaScript and Python

### DIFF
--- a/code-quality/code-formatting-sort-imports/fixes/javascript_prettier-plugin-sort-imports.md
+++ b/code-quality/code-formatting-sort-imports/fixes/javascript_prettier-plugin-sort-imports.md
@@ -1,0 +1,45 @@
+# Setting up Import Sorting with Prettier Plugin
+
+## Installation
+
+Install the Prettier import sorting plugin:
+
+```bash
+npm install --save-dev @trivago/prettier-plugin-sort-imports
+```
+
+## Configuration
+
+Add import sorting configuration to your Prettier config file with the following import order:
+
+1. External library imports (npm packages, including @scoped packages)
+2. Internal/aliased imports (~ or @/ prefixed paths for locally configured module aliases)
+3. Relative imports (. and .. prefixed paths)
+
+Each group should be separated by blank lines.
+
+**.prettierrc**
+```json
+{
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "^(?![~@./]).*$|^@(?!/)",
+    "^[~@]/",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
+}
+```
+
+Note: Common internal alias patterns include `~` and `@/` prefixes, both pointing to src/ or other project root directories.
+
+## Verification
+
+Run the configured format command from package.json scripts:
+
+```bash
+npm run format
+```
+
+If no format script exists, run Prettier directly and verify that imports are automatically grouped and sorted according to the defined order.

--- a/code-quality/code-formatting-sort-imports/fixes/python_isort.md
+++ b/code-quality/code-formatting-sort-imports/fixes/python_isort.md
@@ -1,0 +1,64 @@
+# Setting up Import Sorting with isort
+
+## Installation
+
+Install isort as a development dependency:
+
+```bash
+pip install isort
+```
+
+## Configuration
+
+Configure isort with the following import order:
+
+1. Future imports
+2. Standard library imports  
+3. Third-party library imports
+4. First-party/local application imports
+5. Relative imports from current package
+
+Each group should be separated by blank lines and sorted alphabetically within the group.
+
+**pyproject.toml**
+```toml
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 88
+known_first_party = ["your_package_name"]
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+force_grid_wrap = 0
+combine_as_imports = true
+```
+
+## Integration with Existing Formatters
+
+### With Black
+If using Black, isort is already configured to be compatible via the `profile = "black"` setting above.
+
+### With Ruff  
+If using Ruff as your formatter, configure Ruff to handle import sorting instead:
+
+**pyproject.toml**
+```toml
+[tool.ruff]
+select = ["I"]  # Enable import sorting
+
+[tool.ruff.isort]
+known-first-party = ["your_package_name"]
+```
+
+## Verification
+
+Run the configured format command from your project:
+
+```bash
+# If using a format script in package.json or similar
+npm run format
+
+# Or run isort directly
+isort .
+```
+
+Verify that imports are automatically grouped and sorted according to the defined sections.

--- a/code-quality/code-formatting-sort-imports/metadata.yaml
+++ b/code-quality/code-formatting-sort-imports/metadata.yaml
@@ -1,0 +1,24 @@
+id: code-formatting-sort-imports
+category: code-quality
+summary: Sort imports when running the code formatter
+level: workspace-preferred
+
+ecosystems:
+  - id: javascript
+    default_variant: prettier-plugin-sort-imports
+    variants:
+      - id: prettier-plugin-sort-imports
+        fix_prompt: fixes/javascript_prettier-plugin-sort-imports.md
+  - id: python
+    default_variant: isort
+    variants:
+      - id: isort
+        fix_prompt: fixes/python_isort.md
+
+provides:
+  - code-formatting-sort-imports.exists
+  - code-formatting-sort-imports.variant
+
+requires:
+  - key: code-formatting.exists
+    equals: true

--- a/code-quality/code-formatting-sort-imports/prompt.md
+++ b/code-quality/code-formatting-sort-imports/prompt.md
@@ -1,0 +1,26 @@
+## Goal
+
+Configure automatic import sorting as part of the code formatting workflow.
+
+## Investigation
+
+1. **Check existing formatter configuration**
+   - Look for formatter configuration files (e.g., .prettierrc, pyproject.toml, setup.cfg)
+   - Verify if import sorting is already enabled in the formatter configuration
+   - Check if dedicated import sorting tools are configured separately
+
+2. **Detect current import sorting setup**
+   - Search for import sorting tool configuration files (e.g., .isort.cfg, import-sort configuration)
+   - Check package.json or requirements files for import sorting dependencies
+   - Look for import sorting rules in linter configurations
+
+3. **Identify integration opportunities**
+   - Check if the formatter supports built-in import sorting features
+   - Verify compatibility between existing formatter and import sorting tools
+   - Assess if import sorting can be integrated into the current formatting workflow
+
+## Expected Output
+
+- code-formatting-sort-imports.exists: Whether import sorting is currently configured (boolean)
+- code-formatting-sort-imports.configured: Whether import sorting has been properly set up with the formatter (boolean)
+- code-formatting-sort-imports.variant: The import sorting approach being used (string)


### PR DESCRIPTION
## Summary

- Adds a new `code-formatting-sort-imports` recipe that configures import sorting for existing code formatters
- Supports JavaScript (prettier-plugin-sort-imports) and Python (isort) ecosystems
- Includes integration instructions for popular formatters (Black, Ruff)
- Uses generic import grouping patterns that work across different project structures

## Key Features

- **Proper dependency management**: Requires `code-formatting.exists = true` to ensure base formatters are configured first
- **Generic import patterns**: Uses flexible regex patterns instead of project-specific examples
- **Formatter integration**: Provides instructions for standalone and integrated formatter setups
- **Clear documentation**: Explains import grouping logic and common alias patterns (`~`, `@/`)

## Test Plan

- [x] Recipe applies successfully when code formatting is already configured
- [x] Import sorting works with the configured patterns
- [x] JavaScript variant uses prettier-plugin-sort-imports correctly
- [x] Python variant includes isort with Black/Ruff integration options